### PR TITLE
Hash type usage

### DIFF
--- a/registers/blob.py
+++ b/registers/blob.py
@@ -1,5 +1,6 @@
 from hashlib import sha256
 import json
+from .hash import Hash
 
 
 class Blob:
@@ -22,7 +23,9 @@ class Blob:
     def digest(self):
         """The digest of the Blob according to V1"""
 
-        return sha256(self.to_json().encode('utf-8')).hexdigest()
+        buffer = self.to_json().encode('utf-8')
+
+        return Hash("sha-256", sha256(buffer).hexdigest())
 
     def to_json(self):
         """

--- a/registers/hash.py
+++ b/registers/hash.py
@@ -7,10 +7,10 @@ class Hash:
         self._algorithm = algorithm
         self._digest = digest
 
-    def __hash__(self):
-        return self._digest
+    def __hash__(self) -> int:
+        return int(self._digest, 16)
 
-    def __eq__(self, other):
+    def __eq__(self, other: 'Hash') -> bool:
         return (self.digest == other.digest and
                 self.algorithm == other.algorithm)
 

--- a/registers/hash.py
+++ b/registers/hash.py
@@ -10,7 +10,7 @@ class Hash:
     def __hash__(self) -> int:
         return int(self._digest, 16)
 
-    def __eq__(self, other: 'Hash') -> bool:
+    def __eq__(self, other) -> bool:
         return (self.digest == other.digest and
                 self.algorithm == other.algorithm)
 

--- a/registers/log.py
+++ b/registers/log.py
@@ -17,33 +17,33 @@ class Log:
     """
 
     def __init__(self, entries: List[Entry] = None,
-                 blobs: Dict[str, Blob] = None):
+                 blobs: Dict[Hash, Blob] = None):
         self._entries = entries or []
         self._blobs = blobs or {}
         self._size = len(self._entries)
 
     @property
-    def blobs(self):
+    def blobs(self) -> Dict[Hash, Blob]:
         """
         The set of blobs.
         """
         return self._blobs
 
     @property
-    def entries(self):
+    def entries(self) -> List[Entry]:
         """
         The list of entries.
         """
         return self._entries
 
     @property
-    def size(self):
+    def size(self) -> int:
         """
         The size of the log.
         """
         return self._size
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Checks if the log is empty"""
         return self._size == 0
 
@@ -55,8 +55,7 @@ class Log:
         records = {}
 
         for entry in self._entries[:size]:
-            records[entry.key] = Record(entry,
-                                        self._blobs[entry.blob_hash.digest])
+            records[entry.key] = Record(entry, self._blobs[entry.blob_hash])
 
         return records
 
@@ -125,7 +124,7 @@ def collect(commands: List[Command]) -> Dict[str, Log]:
                 data.insert(command.value)
 
     for entry in data.entries:
-        blob = blobs.get(entry.blob_hash.digest)
+        blob = blobs.get(entry.blob_hash)
 
         if blob is None:
             raise OrphanEntry(entry)
@@ -133,7 +132,7 @@ def collect(commands: List[Command]) -> Dict[str, Log]:
         data.insert(blob)
 
     for entry in metadata.entries:
-        blob = blobs.get(entry.blob_hash.digest)
+        blob = blobs.get(entry.blob_hash)
 
         if blob is None:
             raise OrphanEntry(entry)

--- a/registers/record.py
+++ b/registers/record.py
@@ -8,8 +8,8 @@ class Record:
     Represents a record.
     """
     def __init__(self, entry: Entry, blob: Blob):
-        if entry.blob_hash.digest != blob.digest():
-            raise InconsistentRecord((entry.key, entry.blob_hash.value))
+        if entry.blob_hash != blob.digest():
+            raise InconsistentRecord((entry.key, entry.blob_hash))
 
         self._entry = entry
         self._blob = blob

--- a/registers/register.py
+++ b/registers/register.py
@@ -2,7 +2,7 @@
 The Register representation and utilities to work with it.
 """
 
-from typing import List, Dict
+from typing import List, Dict, Optional
 from .rsf.parser import Command
 from .log import Log, collect
 from .schema import Schema, attribute
@@ -19,7 +19,7 @@ class Register:
     def __init__(self, commands: List[Command] = None):
         self._log = Log()
         self._metalog = Log()
-        self._commands = []
+        self._commands: List[Command] = []
         self._uid = None
         self._update_date = None
 
@@ -60,7 +60,7 @@ class Register:
         }
 
     @property
-    def uid(self) -> str:
+    def uid(self) -> Optional[str]:
         """
         The register unique identifier.
         """
@@ -89,7 +89,7 @@ class Register:
 
         return self._log.snapshot()
 
-    def record(self, key: str) -> Record:
+    def record(self, key: str) -> Optional[Record]:
         """
         Collects the record for the given key.
         """

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,11 +1,14 @@
-from registers import Blob
+from registers import Blob, Hash
 
 
 def test_digest():
     """Should generate a digest following the canonical V1 rules."""
 
     blob = Blob({"register-name": "Country"})
-    expected = '9f21f032105bb320d1f0c4f9c74a84a69e2d0a41932eb4543c331ce73e0bb1fb' # NOQA
+    expected = Hash(
+        "sha-256",
+        "9f21f032105bb320d1f0c4f9c74a84a69e2d0a41932eb4543c331ce73e0bb1fb"
+    )
 
     assert blob.digest() == expected
 
@@ -17,6 +20,9 @@ def test_utf8_digest():
         "name": "Ivory Coast",
         "official-name": "The Republic of Côte D’Ivoire"
     })
-    expected = "b3ca21b3b3a795ab9cd1d10f3d447947328406984f8a461b43d9b74b58cccfe8" # NOQA
+    expected = Hash(
+        "sha-256",
+        "b3ca21b3b3a795ab9cd1d10f3d447947328406984f8a461b43d9b74b58cccfe8"
+    )
 
     assert blob.digest() == expected


### PR DESCRIPTION
### Context

The `Hash` type is used inconsistently across the codebase. For example, `blob.digest` returns a string which makes it awkward to work with in conjunction with `entry.blob_hash`.

### Changes proposed in this pull request

This PR changes `blob.digest` to return a `Hash`. Also fixes `Hash.__hash__` to allow sets and dictionaries to use it as a comparable object.

### Guidance to review

Ensure tests pass:

```
make test
make check
make lint
```