### PR TITLE
Adds the init command able to add the schema attributes

### DIFF
--- a/registers/commands/init.py
+++ b/registers/commands/init.py
@@ -9,22 +9,105 @@ This module implements the init command.
 """
 
 import os
+from hashlib import sha256
+from datetime import datetime
+from typing import List
 import click
-from ..core import EMPTY_ROOT_HASH
+from . import utils
+from .. import (rsf, schema, merkle, Hash, Blob, Entry, Scope,
+                Attribute, Datatype, Cardinality)
+from ..core import format_timestamp
+from ..exceptions import RegistersException
 
 
 @click.command(name="init")
-@click.argument("filepath", type=click.Path(exists=False))
-def init_command(filepath):
-    """Creates an empty register."""
+@click.argument("name")
+@click.option("--rsf", "rsf_file", required=True,
+              type=click.Path(exists=False),
+              help=("The RSF file that will be created as a result of the "
+                    "command"))
+def init_command(name, rsf_file):
+    """
+    Creates a new register with the given NAME to the given RSF file.
+    """
 
-    assert_root_hash = f"assert-root-hash\t{EMPTY_ROOT_HASH}"
-
-    if os.path.exists(filepath):
+    if os.path.exists(rsf_file):
         raise click.UsageError("Please select a file that does not exist.")
 
-    with click.open_file(filepath, "w", "utf-8") as handle:
-        handle.write(assert_root_hash)
+    try:
+        commands = init_patch(name)
 
-    fname = click.style(click.format_filename(filepath), fg='bright_yellow')
-    click.echo(f"Empty register successfully created at {fname}")
+        with click.open_file(rsf_file, "w", "utf-8") as stream:
+            stream.write(rsf.dump(commands))
+
+        fname = click.style(click.format_filename(rsf_file),
+                            fg='bright_yellow')
+        click.echo(f"Empty register successfully created at {fname}")
+
+    except RegistersException as err:
+        utils.error(str(err))
+
+
+def init_patch(name: str) -> List[rsf.Command]:
+    """
+    Creates the initial set of commands from a given name (register uid).
+    """
+
+    timestamp = format_timestamp(datetime.utcnow())
+
+    uid = Blob({"name": name})
+    uid_entry = Entry("name", Scope.System, timestamp,
+                      uid.digest())
+
+    commands = [
+        rsf.assert_root_hash(Hash("sha-256", merkle.hash_empty(sha256).hex())),
+
+        rsf.add_item(uid),
+        rsf.append_entry(uid_entry),
+    ]
+
+    attributes = gather_attributes(name, timestamp)
+
+    commands.extend(attributes)
+
+    return commands
+
+
+def gather_attributes(name: str, timestamp: str) -> List[rsf.Command]:
+    """
+    Gathers attribute information from the user.
+    """
+
+    cmds = []
+
+    primary_key = schema.string(name).to_blob()
+    primary_key_entry = Entry(f"field:{name}", Scope.System, timestamp,
+                              primary_key.digest())
+
+    cmds.append(rsf.add_item(primary_key))
+    cmds.append(rsf.append_entry(primary_key_entry))
+
+    click.echo(f"Primary key {name} added.")
+
+    while True:
+        if click.confirm("Do you want to add an attribute?"):
+            uid = click.prompt("Id:", type=str)
+            datatype = click.prompt("Datatype:",
+                                    type=click.Choice(schema.DATATYPES))
+            cardinality = click.prompt("Cardinality:",
+                                       type=click.Choice(["1", "n"]))
+            description = click.prompt("Description:", type=str)
+
+            attr = Attribute(uid,
+                             Datatype(datatype),
+                             Cardinality(cardinality),
+                             description)
+            blob = attr.to_blob()
+            entry = Entry(f"field:{uid}", Scope.System, timestamp,
+                          blob.digest())
+            cmds.append(rsf.add_item(blob))
+            cmds.append(rsf.append_entry(entry))
+        else:
+            break
+
+    return cmds

--- a/registers/commands/value.py
+++ b/registers/commands/value.py
@@ -9,7 +9,7 @@ This module implements the value command group.
 """
 
 import click
-from .. import validator, Datatype
+from .. import validator, schema, Datatype
 from ..exceptions import RegistersException
 from . import utils
 
@@ -27,16 +27,7 @@ def value_group():
 @value_group.command(name="validate")
 @click.argument("token")
 @click.option("--type", "datatype", required=True,
-              type=click.Choice(["curie",
-                                 "datetime",
-                                 "name",
-                                 "hash",
-                                 "integer",
-                                 "period",
-                                 "string",
-                                 "text",
-                                 "timestamp",
-                                 "url"]),
+              type=click.Choice(schema.DATATYPES),
               help="The datatype TOKEN is expected to conform to.")
 def validate_command(token, datatype):
     """

--- a/registers/rsf/__init__.py
+++ b/registers/rsf/__init__.py
@@ -15,9 +15,9 @@ progress can be found here:
 
 
 from typing import List
-from .core import (Action, Command, # NOQA
-                   add_item, assert_root_hash, append_entry)
-from .parser import parse, load # NOQA
+from .core import (Action, Command,  # NOQA
+                   assert_root_hash, add_item, append_entry)
+from .parser import parse, load  # NOQA
 
 
 def read(filepath: str) -> List[Command]:

--- a/registers/schema.py
+++ b/registers/schema.py
@@ -17,6 +17,18 @@ from .exceptions import AttributeAlreadyExists, MissingAttributeIdentifier
 from .blob import Blob
 
 
+DATATYPES = ["curie",
+             "datetime",
+             "name",
+             "hash",
+             "integer",
+             "period",
+             "string",
+             "text",
+             "timestamp",
+             "url"]
+
+
 class Cardinality(Enum):
     """
     The attribute cardinality representation.
@@ -103,6 +115,13 @@ class Attribute:
 
         return json.dumps(dict(self), separators=(',', ':'),
                           ensure_ascii=False)
+
+    def to_blob(self):
+        """
+        The attribute blob representation.
+        """
+
+        return Blob(self.to_dict())
 
     @property
     def uid(self) -> str:


### PR DESCRIPTION
### Guidance to review

Ensure the `init` command creates a valid RSF file with the given schema.