### PR TITLE
feat: Remove rsf slices

### DIFF
--- a/registers/commands/build.py
+++ b/registers/commands/build.py
@@ -16,7 +16,7 @@ from typing import List, Union, Dict
 import pkg_resources
 import yaml
 import click
-from .. import rsf, log, Register, Entry, Record, Cardinality
+from .. import rsf, Register, Entry, Record, Cardinality
 from ..exceptions import RegistersException
 from . import utils
 from .utils import error
@@ -39,14 +39,12 @@ def build_command(rsf_file, target):
         build
         └── web-colours
             ├── archive.zip
-            ├── commands
-            │  ├── 0.rsf
-            │  ├── 1.rsf
-            .  .
-            .  .
+            ├── commands.rsf
             ├── entries
-            │  ├── 1.rsf
-            │  ├── 2.rsf
+            │  ├── 1.csv
+            │  ├── 1.json
+            │  ├── 2.csv
+            │  ├── 2.json
             .  .
             .  .
             ├── items
@@ -109,7 +107,7 @@ def build_command(rsf_file, target):
         build_blobs(build_path.joinpath("items"), register)
         build_entries(build_path.joinpath("entries"), register)
         build_records(build_path.joinpath("records"), register)
-        build_commands(build_path.joinpath("commands"), register)
+        build_commands(build_path, register)
         build_context(build_path.joinpath("register"), register)
         build_archive(build_path, register)
         build_openapi(build_path, register)
@@ -207,22 +205,8 @@ def build_commands(path: Path, register: Register):
     """
     Generates all RSF files.
     """
-
-    if path.exists():
-        path.rmdir()
-
-    path.mkdir()
-
-    with open(f"{path}/0.rsf", "w") as stream:
+    with open(f"{path}/commands.rsf", "w") as stream:
         stream.write(rsf.dump(register.commands))
-
-    with utils.progressbar(range(1, register.log.size),
-                           label='Building commands') as bar:
-        for idx in bar:
-            commands = log.slice(register.log, idx)
-
-            with open(f"{path}/{idx}.rsf", "w") as stream:
-                stream.write(rsf.dump(commands))
 
 
 def build_context(path: Path, register: Register):

--- a/registers/data/netlify/_redirects
+++ b/registers/data/netlify/_redirects
@@ -40,9 +40,8 @@
 
 
 # RSF
-/commands	/commands/0.rsf	200
-/download-rsf	/commands/0.rsf	200
-/download-rsf/:slice	/commands/:slice.rsf	200
+/commands	/commands.rsf	200
+/download-rsf	/commands.rsf	200
 
 
 # Archive

--- a/registers/data/nginx/default.conf
+++ b/registers/data/nginx/default.conf
@@ -163,14 +163,13 @@ server {
   location /download-rsf {
     default_type application/uk-gov-rsf;
 
-    rewrite ^/download-rsf$ /commands/0.rsf;
-    rewrite ^/download-rsf/(.*)$ /commands/$1.rsf last;
+    rewrite ^/download-rsf$ /commands.rsf last;
   }
 
   location = /commands {
     default_type application/uk-gov-rsf;
 
-    alias public/commands/0.rsf;
+    alias public/commands.rsf;
   }
 
 


### PR DESCRIPTION
### Context

Frontend now loads full rsf so rsf slicing is deprecated

Co-Authored-By: Arnau Siches <arnau.siches@digital.cabinet-office.gov.uk>
Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>

### Changes proposed in this pull request

- building now produces a single `commands.rsf` instead of a directory `commands` with all the slices

### Guidance to review

Run to verify it produces the result above:

```
pipenv run ./reg build tests/fixtures/country.rsf
```