### PR TITLE
RED-103: Fix pip dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "Click~=7.0",
+        "PyYAML~=5.1",
+        "Jinja2~=2.10",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
### Context
When installing the registers-cli on a Docker image, it complains about
`yaml` and `jinja` being missing. Probably because the python3 Docker image
doesn't have any of this stuff ready to go.


### Changes proposed in this pull request
Add the `PyYAML` and `Jinja2` dependencies to `setup.py`.


### Guidance to review
Run `pip3 install --user .` to test.