### PR TITLE
RED-103: Create Docker version of Registers CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python@sha256:083192ca72d1e948e76377b8e011d26da64fe160c8a9a162d04c4a89b2d01e44
+
+WORKDIR /var/app
+
+COPY . .
+
+RUN apk add git --update && \
+    pip install git+https://github.com/openregister/registers-cli#egg=registers
+
+ENTRYPOINT [ "registers" ]
+
+CMD [ "--help" ]


### PR DESCRIPTION
### Context

We'd like to be using a Dockerised version of Registers CLI in our CI/CD
tooling, such as Concourse.

This should be used in a way to generate some files for static
consumption.

### Changes proposed in this pull request

Docker image

### Guidance to review

```
docker run --rm -it $(docker build -q .)
```

see help