### PR TITLE
RED-103: Add the necessary package_data to CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,14 @@ setup(
     packages=find_packages(),
     package_data={
         '': ["LICENSE"],
-        'registers': ['data/_redirects', 'data/openapi.json']
+        'registers': [
+            'data/_redirects',
+            'data/openapi.json',
+            'data/cloudfoundry/*',
+            'data/docker/*',
+            'data/netlify/*',
+            'data/nginx/*',
+            ],
     },
     include_package_data=True,
     python_requires=">=3.6",


### PR DESCRIPTION
### Context
The CLI expects certain files from the `data/` directory to be
installed along with its source.

### Changes proposed in this pull request
Add the necessary data files to the list in `setup.py`.

### Guidance to review
Install the CLI and check that all the build targets work *when not in
this source directory*.