### PR TITLE
RED-103: Add more stuff to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
             'data/docker/*',
             'data/netlify/*',
             'data/nginx/*',
+            'data/nginx/lua/*',
             ],
     },
     include_package_data=True,


### PR DESCRIPTION
### Context
Was missing the `data/nginx/lua/` directory.


### Changes proposed in this pull request
Added the dir


### Guidance to review
As before