### PR TITLE
RED-103: Build the docker image from local source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python@sha256:083192ca72d1e948e76377b8e011d26da64fe160c8a9a162d04c4a89b2d01e44
-
-RUN apk add git --update && \
-    pip install git+https://github.com/openregister/registers-cli#egg=registers
-
+WORKDIR /app
+COPY . .
+RUN pip install .
 ENTRYPOINT [ "registers" ]
-
 CMD [ "--help" ]


### PR DESCRIPTION
### Context
We ran into weird issues where changes didn't show up in the built
docker image because the source was actually being pulled from the github repo.
Also permits building on network-restricted boxes.

### Changes proposed in this pull request
Copy the source into the image and build.

### Guidance to review
Build the docker image and run it