### PR TITLE
Enhance CloudFoundry configuration

### DIFF
--- a/registers/data/cloudfoundry/manifest.yml
+++ b/registers/data/cloudfoundry/manifest.yml
@@ -2,3 +2,5 @@
 applications:
 - name: change-me
   buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+  instances: 2
+  memory: 64M

--- a/registers/data/nginx/default.conf
+++ b/registers/data/nginx/default.conf
@@ -18,6 +18,8 @@ server {
 
   more_set_headers "Server: registers/0.1";
 
+  expires 0;
+  add_header Cache-Control "no-cache";
 
   # Remove trailing slashes ##################################################
 


### PR DESCRIPTION
### Context

The default memory is resolving to 1GB. This, although optimistic, is
probably not necessary. With an idea of serving static files, we can
save some resources to the GOV.UK PaaS team.

The number of instances for production, is recommended to be 2+. The
default is sadly 1. The reason behind this, is that the apps can be
taken away and spun elsewhere due to some maintenance or issues. Having
more, means potentially having less downtime.

The CDN in front of our app will use these information to manage it's
own cache. Since we believe we don't want to be caching anything, as it
may impact our metrics, we'd like to make sure it will never be set.

### Changes proposed in this pull request

- Number of instances increased: `2`
- Amount of memory allocation reduced: `64M`
- Disabling cache in NGINX

### Guidance to review

- Sanity check