### PR TITLE
REP-355: Fix OpenResty on PaaS

### DIFF
--- a/registers/data/cloudfoundry/manifest.yml
+++ b/registers/data/cloudfoundry/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: change-me
-  buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+  buildpacks:
+    - https://github.com/cloudfoundry/nginx-buildpack.git
   instances: 2
   memory: 64M

--- a/registers/data/nginx/default.conf
+++ b/registers/data/nginx/default.conf
@@ -5,7 +5,8 @@ map $http_accept $format {
   application/json json;
 }
 
-lua_package_path "/usr/local/openresty/nginx/lua/?.lua;;";
+lua_package_path "$prefix/lua/?.lua;/home/vcap/deps/0/nginx/lualib/?.lua;/usr/local/openresty/nginx/lua/?.lua;;";
+lua_package_cpath "/home/vcap/deps/0/nginx/lualib/?.so;;";
 
 server {
   absolute_redirect off;


### PR DESCRIPTION
### Context
The nginx buildpack seems to install openresty modules to weird
locations so we need to make some changes to use our Lua code.

### Changes proposed in this pull request
- Add extra paths to `lua_package_path` and `lua_package_cpath`
- Use `buildpacks:` instead of `buildpack:` because the latter is being
deprecated

### Guidance to review
Deploy app to PaaS and make sure the `?start=<number>` query param
works.